### PR TITLE
Fix equality testing

### DIFF
--- a/src/Numeric/Compensated.hs
+++ b/src/Numeric/Compensated.hs
@@ -320,7 +320,7 @@ instance (Applicative f, Compensable a, Compensable b) => Each f (Compensated a)
 
 instance Compensable a => Eq (Compensated a) where
   m == n = with m $ \a b -> with n $ \c d -> a == c && b == d
-  m /= n = with m $ \a b -> with n $ \c d -> a /= c && b /= d
+  m /= n = with m $ \a b -> with n $ \c d -> a /= c || b /= d
   {-# INLINE (==) #-}
 
 instance Compensable a => Ord (Compensated a) where


### PR DESCRIPTION
If m and n had matching primals xor residuals, m/=n == False but m==n == False. This fixes that.
