### PR TITLE
Improved version of add

### DIFF
--- a/src/Numeric/Compensated.hs
+++ b/src/Numeric/Compensated.hs
@@ -91,8 +91,8 @@ import Text.Show as T
 add :: Num a => a -> a -> (a -> a -> r) -> r
 add a b k = k x y where
   x = a + b
-  z = x - a
-  y = (a - (x - z)) + (b - z)
+  q = x - a
+  y = b - q
 {-# INLINE add #-}
 
 -- | @'fadd' a b k@ computes @k x y@ such that


### PR DESCRIPTION
The current add function uses an old algorithm for the error free sum of two floating point numbers. Pages 8-9 of www.ti3.tu-harburg.de/paper/rump/RuOgOi07I.pdf give an algorithm with the same results that only uses 3 flops.
